### PR TITLE
fix(player): Fix toggle playback hotkey overlapping with button activation

### DIFF
--- a/src/shared/keyboard/useKeydown.ts
+++ b/src/shared/keyboard/useKeydown.ts
@@ -36,7 +36,7 @@ export function useKeydown(
 /**
  * Element selector for ignoring keyboard events
  */
-const ignoreKeyboardSelector = 'input';
+const ignoreKeyboardSelector = 'input,select,textarea,a,button,[role="button"]';
 
 /**
  * Boolean check for ignore selector


### PR DESCRIPTION
### What this does

Add more elements to the ignoreKeyboardSelector, allowing SPACE to be used to activate links/buttons/etc. while a podcast is playing. Fixes #50.

I added the most common/obvious possibilities at this time

### How to test

1. Start playing a podcast episode
2. `TAB` to something, e.g. the Subscribe button
3. You can now press `SPACE` to activate the button, and the podcast won't instead stop/start playing

