### PR TITLE
Show loader for route changes

### DIFF
--- a/src/components/PodcastApp/PodcstApp.tsx
+++ b/src/components/PodcastApp/PodcstApp.tsx
@@ -10,6 +10,7 @@ import { Player } from '../../shared/player/Player';
 import { ThemeListener } from '../../shared/theme/ThemeListener';
 import { getInit, useSubscriptions } from '../../shared/subscriptions/useSubscriptions';
 import { CastManager } from '../CastManager/CastManager';
+import { RouteTransistion } from '../RouteTransistion';
 import { Toast } from '../../shared/toast/Toast';
 
 export default function App({ Component, pageProps }: AppProps) {
@@ -68,6 +69,7 @@ export default function App({ Component, pageProps }: AppProps) {
       <Player />
       <ThemeListener />
       <CastManager />
+      <RouteTransistion />
       <Script>
         {`
         window['__onGCastApiAvailable'] = function(isAvailable) {

--- a/src/components/RouteTransistion/RouteTransistion.tsx
+++ b/src/components/RouteTransistion/RouteTransistion.tsx
@@ -1,0 +1,26 @@
+import { useRouter } from "next/router";
+import { useEffect, useState } from "react";
+
+import { LoadBar } from "../../ui/LoadBar";
+
+export function RouteTransistion() {
+  const [inTransistion, setInTransistion] = useState(false);
+  const router = useRouter();
+  useEffect(() => {
+    const startTransistion = () => setInTransistion(true);
+    const endTransistion = () => setInTransistion(false);
+
+    router.events.on('routeChangeStart', startTransistion);
+    router.events.on('routeChangeComplete', endTransistion);
+    router.events.on('routeChangeError', endTransistion);
+
+    return () => {
+      router.events.off('routeChangeStart', startTransistion);
+      router.events.off('routeChangeComplete', endTransistion);
+      router.events.off('routeChangeError', endTransistion);
+    }
+  }, [router]);
+  return (
+    inTransistion ? <LoadBar /> : null
+  );
+}

--- a/src/components/RouteTransistion/index.ts
+++ b/src/components/RouteTransistion/index.ts
@@ -1,0 +1,1 @@
+export * from './RouteTransistion';


### PR DESCRIPTION
- Show loader when router starts a route change
- Hide loader on route change complete / error
- Improves perceived performance when the app is loading a larger uncached feed (The Daily)