### PR TITLE
Implement new shortcuts

### DIFF
--- a/src/shared/keyboard/shortcuts.ts
+++ b/src/shared/keyboard/shortcuts.ts
@@ -1,99 +1,181 @@
-export interface IShortcutInfo {
-  title: string;
-  key: string;
-  displayKey: string;
-  metaKey: boolean;
+export interface IKeyboardShortcut {
+    key: string;
+    metaKey: boolean;
+    shiftKey: boolean;
 }
 
-export const shortcuts = {
+export interface IShortcutInfo extends IKeyboardShortcut {
+  title: string;
+  displayKey: string;
+  secondary?: IKeyboardShortcut[];
+}
+
+type DisplayableShortcuts =
+  | 'home'
+  | 'subscriptions'
+  | 'recents'
+  | 'settings'
+  | 'search'
+  | 'theme'
+  | 'info'
+  | 'queue'
+  | 'togglePlayback'
+  | 'seekBack'
+  | 'seekAhead'
+  | 'seekTo'
+  | 'nextEpisode'
+  | 'previousEpisode'
+  | 'bumpRate'
+  | 'decreaseRate'
+  | 'mute'
+  | 'shortcuts';
+
+export const shortcuts: Record<DisplayableShortcuts, IShortcutInfo> = {
   home: {
     title: 'Home / Top',
     key: 'h',
     displayKey: 'h',
     metaKey: false,
+    shiftKey: false,
   },
   subscriptions: {
     title: 'Subscriptions',
     key: 's',
     displayKey: 's',
     metaKey: false,
+    shiftKey: false,
   },
   recents: {
     title: 'Recents',
     key: 'r',
     displayKey: 'r',
     metaKey: false,
+    shiftKey: false,
   },
   settings: {
     title: 'Settings',
     key: ',',
     displayKey: ',',
     metaKey: false,
-  },
-  drawer: {
-    title: 'Toggle drawer',
-    key: 'd',
-    displayKey: 'd',
-    metaKey: false,
+    shiftKey: false,
   },
   search: {
     title: 'Search',
     key: '/',
     displayKey: '/',
     metaKey: false,
+    shiftKey: false,
   },
   theme: {
     title: 'Toggle theme',
     key: 't',
     displayKey: 't',
     metaKey: false,
+    shiftKey: false,
   },
   info: {
     title: 'Show episode info',
     key: 'i',
     displayKey: 'i',
     metaKey: false,
+    shiftKey: false,
+  },
+  queue: {
+    title: 'Queue',
+    key: 'q',
+    displayKey: 'q',
+    metaKey: false,
+    shiftKey: false,
   },
   togglePlayback: {
     title: 'Play / Pause',
-    key: ' ',
-    displayKey: 'space',
+    key: 'k',
+    displayKey: 'k',
     metaKey: false,
+    shiftKey: false,
+    secondary: [
+      {
+        key: ' ',
+        metaKey: false,
+        shiftKey: false,
+      },
+    ],
   },
   seekBack: {
     title: 'Seek back',
-    key: 'ArrowLeft',
-    displayKey: '←',
+    key: 'j',
+    displayKey: 'j',
     metaKey: false,
+    shiftKey: false,
+    secondary: [
+      {
+        key: 'ArrowLeft',
+        metaKey: false,
+        shiftKey: false,
+      },
+    ],
   },
   seekAhead: {
     title: 'Seek ahead',
-    key: 'ArrowRight',
-    displayKey: '→',
+    key: 'l',
+    displayKey: 'l',
     metaKey: false,
+    shiftKey: false,
+    secondary: [
+      {
+        key: 'ArrowRight',
+        metaKey: false,
+        shiftKey: false,
+      },
+    ],
   },
   seekTo: {
     title: 'Seek to n %',
     key: '*',
     displayKey: '0-9',
     metaKey: false,
+    shiftKey: false,
+  },
+  nextEpisode: {
+    title: 'Next episode',
+    key: 'N',
+    displayKey: 'shift + n',
+    metaKey: false,
+    shiftKey: true,
+  },
+  previousEpisode: {
+    title: 'Previous episode',
+    key: 'P',
+    displayKey: 'shift + p',
+    metaKey: false,
+    shiftKey: true,
   },
   bumpRate: {
     title: 'Increase playback rate',
     key: '>',
     displayKey: '>',
     metaKey: false,
+    shiftKey: false,
   },
   decreaseRate: {
     title: 'Lower playback rate',
     key: '<',
     displayKey: '<',
     metaKey: false,
+    shiftKey: false,
   },
-  closeDrawer: {
-    title: 'Close drawer',
-    key: 'Escape',
-    displayKey: 'esc',
+  mute: {
+    title: 'Toggle mute',
+    key: 'm',
+    displayKey: 'm',
     metaKey: false,
+    shiftKey: false,
   },
-} as const;
+  shortcuts: {
+    title: 'Show shortcuts',
+    key: '?',
+    displayKey: 'shift + ?',
+    metaKey: false,
+    shiftKey: true,
+  },
+};

--- a/src/shared/keyboard/useGlobalShortcuts.ts
+++ b/src/shared/keyboard/useGlobalShortcuts.ts
@@ -34,5 +34,11 @@ const globalShortcuts: KeyboardShortcuts = [
       router.push('/settings');
     },
   ],
+  [
+    shortcuts.shortcuts,
+    () => {
+      router.push('/settings/shortcuts');
+    },
+  ],
   [shortcuts.theme, cycleTheme],
 ];

--- a/src/shared/keyboard/useKeydown.ts
+++ b/src/shared/keyboard/useKeydown.ts
@@ -1,5 +1,5 @@
 import React from 'react';
-import { IShortcutInfo } from './shortcuts';
+import { IKeyboardShortcut, IShortcutInfo } from './shortcuts';
 
 type ShortcutHandler = (e: KeyboardEvent) => void;
 export type KeyboardShortcuts = Array<[IShortcutInfo, ShortcutHandler]>;
@@ -44,6 +44,18 @@ const ignoreKeyboardSelector = 'input,select,textarea,a,button,[role="button"]';
 const isNotIgnoreElement = (target: EventTarget | null) =>
   !!target && !(target as HTMLElement).matches(ignoreKeyboardSelector);
 
+const isMatchingShortcut = (e: KeyboardEvent, config: IKeyboardShortcut) => {
+  return (
+    e.metaKey === config.metaKey &&
+    e.shiftKey === config.shiftKey &&
+    (e.key === config.key || config.key === '*')
+  );
+};
+
 const isMatchingEvent = (e: KeyboardEvent, config: IShortcutInfo) => {
-  return e.metaKey === config.metaKey && (e.key === config.key || config.key === '*');
+  return (
+    isMatchingShortcut(e, config) ||
+    config.secondary?.some((shortcut) => isMatchingShortcut(e, shortcut)) ||
+    false
+  );
 };

--- a/src/shared/player/Player.tsx
+++ b/src/shared/player/Player.tsx
@@ -15,7 +15,13 @@ import { VolumeControls } from './VolumeControls';
 
 import styles from './Player.module.css';
 
-const { togglePlayback, seekBackward, seekForward } = usePlayer.getState();
+const {
+  togglePlayback,
+  seekBackward,
+  seekForward,
+  skipToNextEpisode,
+  skipToPreviousEpisode,
+} = usePlayer.getState();
 
 export const Player = () => {
   const currentEpisode = usePlayer(getCurrentEpisode);
@@ -100,6 +106,12 @@ const playerShortcuts: KeyboardShortcuts = [
     },
   ],
   [
+    shortcuts.queue,
+    () => {
+      router.push('/queue');
+    },
+  ],
+  [
     shortcuts.togglePlayback,
     (e) => {
       e.preventDefault();
@@ -108,5 +120,7 @@ const playerShortcuts: KeyboardShortcuts = [
   ],
   [shortcuts.seekBack, seekBackward],
   [shortcuts.seekAhead, seekForward],
+  [shortcuts.previousEpisode, skipToPreviousEpisode],
+  [shortcuts.nextEpisode, skipToNextEpisode],
 ];
 const emptyShortcuts: KeyboardShortcuts = [];

--- a/src/shared/player/VolumeControls.tsx
+++ b/src/shared/player/VolumeControls.tsx
@@ -1,6 +1,8 @@
 import { ChangeEvent, useCallback, useEffect, useMemo, useState } from 'react';
 
 import { Icon } from '../../ui/icons/svg/Icon';
+import { shortcuts } from '../keyboard/shortcuts';
+import { KeyboardShortcuts, useKeydown } from '../keyboard/useKeydown';
 
 import styles from './Player.module.css';
 import {
@@ -34,6 +36,14 @@ export const VolumeControls = () => {
   useEffect(() => {
     mute(muted);
   }, [muted]);
+
+  const rateShortcuts: KeyboardShortcuts = useMemo(
+    () => [
+      [shortcuts.mute, toggleMute],
+    ],
+    [toggleMute],
+  );
+  useKeydown(rateShortcuts);
 
   return (
     <div className={styles.volumeControl}>

--- a/src/shared/player/usePlayer.ts
+++ b/src/shared/player/usePlayer.ts
@@ -212,7 +212,7 @@ export const usePlayer = create<IPlayerState>((set, get) => ({
       currentTrackIndex:
         prevState.currentTrackIndex === 0
           ? prevState.queue.length - 1
-          : (prevState.currentTrackIndex - 1) / prevState.queue.length,
+          : prevState.currentTrackIndex - 1,
     })),
 
   seekBackward: () => {

--- a/src/ui/Header/Header.tsx
+++ b/src/ui/Header/Header.tsx
@@ -14,8 +14,6 @@ export function Header() {
 
   const onHeaderClick = useCallback(() => toggleDrawer(drawerRef.current), []);
   const onCloseDrawer = useCallback(() => closeDrawer(drawerRef.current), []);
-  useKeydown(shortcuts.drawer, onHeaderClick);
-  useKeydown(shortcuts.closeDrawer, onCloseDrawer);
 
   useEffect(() => {
     const closeOnClickOutside = (event: MouseEvent) => {


### PR DESCRIPTION
Implement new shortcuts

- Remove drawer shortcut
- Drawer isn't visible on desktop anymore

- Add support for secondary shortcuts
- Multiple shortcut combinations can be specfied for a key
- Only primary action is shown to user

- Implement new player shortcuts
- Add support for going to shortcuts page
- Add shortcut to go to queue

Closes #61
